### PR TITLE
Add terminal recording content to GitHub step summary for failed CLI E2E tests

### DIFF
--- a/tests/Aspire.Cli.EndToEnd.Tests/DoctorCommandTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/DoctorCommandTests.cs
@@ -32,6 +32,9 @@ public sealed class DoctorCommandTests(ITestOutputHelper output)
 
         await auto.InstallAspireCliInDockerAsync(installMode, counter);
 
+        // INTENTIONAL TEST FAILURE: Validate that cast recording content appears in GitHub step summary
+        Assert.Fail("Intentional failure to test cast recording in step summary (DoctorCommand_WithoutSslCertDir)");
+
         // Generate and trust dev certs inside the container (Docker images don't have them by default)
         await auto.TypeAsync("dotnet dev-certs https --trust 2>/dev/null || dotnet dev-certs https");
         await auto.EnterAsync();
@@ -70,6 +73,9 @@ public sealed class DoctorCommandTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
 
         await auto.InstallAspireCliInDockerAsync(installMode, counter);
+
+        // INTENTIONAL TEST FAILURE: Validate that cast recording content appears in GitHub step summary
+        Assert.Fail("Intentional failure to test cast recording in step summary (DoctorCommand_WithSslCertDir)");
 
         // Generate and trust dev certs inside the container (Docker images don't have them by default)
         await auto.TypeAsync("dotnet dev-certs https --trust 2>/dev/null || dotnet dev-certs https");

--- a/tests/Aspire.Cli.EndToEnd.Tests/ListStepsTests.cs
+++ b/tests/Aspire.Cli.EndToEnd.Tests/ListStepsTests.cs
@@ -32,6 +32,9 @@ public sealed class ListStepsTests(ITestOutputHelper output)
         await auto.PrepareDockerEnvironmentAsync(counter, workspace);
         await auto.InstallAspireCliInDockerAsync(installMode, counter);
 
+        // INTENTIONAL TEST FAILURE: Validate that cast recording content appears in GitHub step summary
+        Assert.Fail("Intentional failure to test cast recording in step summary (DoListStepsShowsPipelineSteps)");
+
         // Create a new Aspire project
         await auto.AspireNewAsync("ListStepsApp", counter);
 

--- a/tools/GenerateTestSummary/CastFileReader.cs
+++ b/tools/GenerateTestSummary/CastFileReader.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Aspire.TestTools;
+
+/// <summary>
+/// Reads asciicast v2 (.cast) recording files and extracts plain text content.
+/// </summary>
+static partial class CastFileReader
+{
+    private const int MaxTextLength = 5_000;
+
+    /// <summary>
+    /// Reads the terminal recording text for a given test method name.
+    /// Looks for a .cast file in the specified recordings directory,
+    /// extracts the output event text, and strips ANSI escape codes.
+    /// </summary>
+    /// <returns>The extracted plain text, or <c>null</c> if no recording file was found.</returns>
+    public static string? ReadRecordingText(string recordingsDir, string testMethodName)
+    {
+        if (!Directory.Exists(recordingsDir))
+        {
+            return null;
+        }
+
+        var castPath = Path.Combine(recordingsDir, $"{testMethodName}.cast");
+        if (!File.Exists(castPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            return ExtractTextFromCastFile(castPath);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Warning: Failed to read recording file {castPath}: {ex.Message}");
+            return null;
+        }
+    }
+
+    private static string? ExtractTextFromCastFile(string castPath)
+    {
+        var sb = new StringBuilder();
+        var headerSkipped = false;
+
+        foreach (var line in File.ReadLines(castPath))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (!headerSkipped)
+            {
+                headerSkipped = true;
+                continue;
+            }
+
+            try
+            {
+                using var doc = JsonDocument.Parse(line);
+                var arr = doc.RootElement;
+                if (arr.ValueKind is not JsonValueKind.Array || arr.GetArrayLength() < 3)
+                {
+                    continue;
+                }
+
+                var eventType = arr[1].GetString();
+                var data = arr[2].GetString();
+
+                if (eventType is not "o" || data is null)
+                {
+                    continue;
+                }
+
+                sb.Append(data);
+            }
+            catch (JsonException)
+            {
+                // Skip malformed event lines.
+            }
+        }
+
+        var rawText = sb.ToString();
+        var plainText = StripAnsiEscapes(rawText);
+
+        if (plainText.Length > MaxTextLength)
+        {
+            plainText = string.Concat(plainText.AsSpan(0, MaxTextLength), "\n\n… (truncated)");
+        }
+
+        return plainText.Length > 0 ? plainText : null;
+    }
+
+    private static string StripAnsiEscapes(string text)
+    {
+        return AnsiEscapeRegex().Replace(text, string.Empty);
+    }
+
+    /// <summary>
+    /// Matches ANSI escape sequences:
+    /// - CSI sequences: ESC [ ... letter (e.g., colors, cursor movement)
+    /// - OSC sequences: ESC ] ... BEL (e.g., terminal title)
+    /// - Two-character escapes: ESC followed by a single character
+    /// </summary>
+    [GeneratedRegex(@"\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07]*\x07|\x1b[^[\]][^\x1b]?")]
+    private static partial Regex AnsiEscapeRegex();
+}

--- a/tools/GenerateTestSummary/CastFileReader.cs
+++ b/tools/GenerateTestSummary/CastFileReader.cs
@@ -12,7 +12,7 @@ namespace Aspire.TestTools;
 /// </summary>
 static partial class CastFileReader
 {
-    private const int MaxTextLength = 5_000;
+    private const int MaxLines = 100;
 
     /// <summary>
     /// Reads the terminal recording text for a given test method name.
@@ -90,12 +90,20 @@ static partial class CastFileReader
         var rawText = sb.ToString();
         var plainText = StripAnsiEscapes(rawText);
 
-        if (plainText.Length > MaxTextLength)
+        if (plainText.Length == 0)
         {
-            plainText = string.Concat(plainText.AsSpan(0, MaxTextLength), "\n\n… (truncated)");
+            return null;
         }
 
-        return plainText.Length > 0 ? plainText : null;
+        // Keep only the last N lines so the summary shows the most recent output.
+        var lines = plainText.Split('\n');
+        if (lines.Length > MaxLines)
+        {
+            var tail = lines.AsSpan(lines.Length - MaxLines);
+            plainText = $"… ({lines.Length - MaxLines} lines omitted)\n{string.Join('\n', tail.ToArray())}";
+        }
+
+        return plainText;
     }
 
     private static string StripAnsiEscapes(string text)

--- a/tools/GenerateTestSummary/CastFileReader.cs
+++ b/tools/GenerateTestSummary/CastFileReader.cs
@@ -3,23 +3,24 @@
 
 using System.Text;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 
 namespace Aspire.TestTools;
 
 /// <summary>
-/// Reads asciicast v2 (.cast) recording files and extracts plain text content.
+/// Reads asciicast v2 (.cast) recording files and extracts terminal output text.
+/// ANSI escape codes are preserved so the output can be rendered with color
+/// inside a <c>```ansi</c> fenced code block in GitHub markdown.
 /// </summary>
-static partial class CastFileReader
+static class CastFileReader
 {
     private const int MaxLines = 100;
 
     /// <summary>
     /// Reads the terminal recording text for a given test method name.
-    /// Looks for a .cast file in the specified recordings directory,
-    /// extracts the output event text, and strips ANSI escape codes.
+    /// Looks for a .cast file in the specified recordings directory and
+    /// extracts the output event text, preserving ANSI escape codes.
     /// </summary>
-    /// <returns>The extracted plain text, or <c>null</c> if no recording file was found.</returns>
+    /// <returns>The extracted text (with ANSI codes), or <c>null</c> if no recording file was found.</returns>
     public static string? ReadRecordingText(string recordingsDir, string testMethodName)
     {
         if (!Directory.Exists(recordingsDir))
@@ -87,36 +88,21 @@ static partial class CastFileReader
             }
         }
 
-        var rawText = sb.ToString();
-        var plainText = StripAnsiEscapes(rawText);
+        var text = sb.ToString();
 
-        if (plainText.Length == 0)
+        if (text.Length == 0)
         {
             return null;
         }
 
         // Keep only the last N lines so the summary shows the most recent output.
-        var lines = plainText.Split('\n');
+        var lines = text.Split('\n');
         if (lines.Length > MaxLines)
         {
             var tail = lines.AsSpan(lines.Length - MaxLines);
-            plainText = $"… ({lines.Length - MaxLines} lines omitted)\n{string.Join('\n', tail.ToArray())}";
+            text = $"… ({lines.Length - MaxLines} lines omitted)\n{string.Join('\n', tail.ToArray())}";
         }
 
-        return plainText;
+        return text;
     }
-
-    private static string StripAnsiEscapes(string text)
-    {
-        return AnsiEscapeRegex().Replace(text, string.Empty);
-    }
-
-    /// <summary>
-    /// Matches ANSI escape sequences:
-    /// - CSI sequences: ESC [ ... letter (e.g., colors, cursor movement)
-    /// - OSC sequences: ESC ] ... BEL (e.g., terminal title)
-    /// - Two-character escapes: ESC followed by a single character
-    /// </summary>
-    [GeneratedRegex(@"\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07]*\x07|\x1b[^[\]][^\x1b]?")]
-    private static partial Regex AnsiEscapeRegex();
 }

--- a/tools/GenerateTestSummary/CastFileReader.cs
+++ b/tools/GenerateTestSummary/CastFileReader.cs
@@ -3,15 +3,17 @@
 
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace Aspire.TestTools;
 
 /// <summary>
 /// Reads asciicast v2 (.cast) recording files and extracts terminal output text.
-/// ANSI escape codes are preserved so the output can be rendered with color
-/// inside a <c>```ansi</c> fenced code block in GitHub markdown.
+/// Only SGR color/style codes (<c>\e[...m</c>) are preserved for rendering inside
+/// a <c>```ansi</c> fenced code block in GitHub markdown. All other escape sequences
+/// (cursor movement, private modes, OSC, etc.) are stripped.
 /// </summary>
-static class CastFileReader
+static partial class CastFileReader
 {
     private const int MaxLines = 100;
 
@@ -88,7 +90,7 @@ static class CastFileReader
             }
         }
 
-        var text = sb.ToString();
+        var text = StripNonSgrEscapes(sb.ToString());
 
         if (text.Length == 0)
         {
@@ -105,4 +107,27 @@ static class CastFileReader
 
         return text;
     }
+
+    /// <summary>
+    /// Strips all ANSI escape sequences except SGR (Select Graphic Rendition)
+    /// codes which control color and text style (<c>\e[...m</c>).
+    /// GitHub's <c>```ansi</c> block only renders SGR; other sequences
+    /// (cursor movement, private modes, OSC, etc.) render as garbage.
+    /// </summary>
+    private static string StripNonSgrEscapes(string text)
+    {
+        return NonSgrEscapeRegex().Replace(text, string.Empty);
+    }
+
+    /// <summary>
+    /// Matches ANSI escape sequences that are NOT SGR (<c>\e[...m</c>):
+    /// <list type="bullet">
+    /// <item>CSI sequences ending in any letter except 'm': <c>\e[...X</c> (cursor, erase, scroll, modes)</item>
+    /// <item>CSI private mode sequences: <c>\e[?...h</c>, <c>\e[?...l</c>, etc.</item>
+    /// <item>OSC sequences: <c>\e]...BEL</c> or <c>\e]...\e\\</c></item>
+    /// <item>Two-character escapes: <c>\eX</c> where X is not '[' or ']'</item>
+    /// </list>
+    /// </summary>
+    [GeneratedRegex(@"\x1b\[\?[0-9;]*[A-Za-z]|\x1b\[[0-9;]*[A-La-lN-Zn-z]|\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b[^[\]m][^\x1b]?")]
+    private static partial Regex NonSgrEscapeRegex();
 }

--- a/tools/GenerateTestSummary/TestSummaryGenerator.cs
+++ b/tools/GenerateTestSummary/TestSummaryGenerator.cs
@@ -315,7 +315,17 @@ sealed partial class TestSummaryGenerator
             return;
         }
 
-        var recordingText = CastFileReader.ReadRecordingText(recordingsDir, testName);
+        // The .cast file is named by the test method name (via [CallerMemberName]),
+        // but TRX TestName is fully qualified (e.g., "Namespace.Class.Method").
+        // Extract just the method name portion.
+        var methodName = testName;
+        var lastDot = testName.LastIndexOf('.');
+        if (lastDot >= 0 && lastDot < testName.Length - 1)
+        {
+            methodName = testName[(lastDot + 1)..];
+        }
+
+        var recordingText = CastFileReader.ReadRecordingText(recordingsDir, methodName);
         if (recordingText is null)
         {
             return;

--- a/tools/GenerateTestSummary/TestSummaryGenerator.cs
+++ b/tools/GenerateTestSummary/TestSummaryGenerator.cs
@@ -299,7 +299,7 @@ sealed partial class TestSummaryGenerator
 
                 reportBuilder.AppendLine("```");
 
-                AppendRecordingSection(reportBuilder, recordingsDir, test.TestName);
+                AppendRecordingSection(reportBuilder, recordingsDir, test.TestName, test.Output?.ErrorInfoString);
 
                 reportBuilder.AppendLine();
                 reportBuilder.AppendLine("</div>");
@@ -308,9 +308,16 @@ sealed partial class TestSummaryGenerator
         reportBuilder.AppendLine();
     }
 
-    private static void AppendRecordingSection(StringBuilder reportBuilder, string? recordingsDir, string? testName)
+    private static void AppendRecordingSection(StringBuilder reportBuilder, string? recordingsDir, string? testName, string? errorInfo)
     {
         if (recordingsDir is null || testName is null)
+        {
+            return;
+        }
+
+        // Hex1bAutomationException already includes a terminal snapshot in the error.
+        // Skip the recording section to avoid redundant output.
+        if (errorInfo is not null && errorInfo.Contains("Terminal snapshot at failure", StringComparison.Ordinal))
         {
             return;
         }

--- a/tools/GenerateTestSummary/TestSummaryGenerator.cs
+++ b/tools/GenerateTestSummary/TestSummaryGenerator.cs
@@ -339,12 +339,9 @@ sealed partial class TestSummaryGenerator
         }
 
         reportBuilder.AppendLine();
-        reportBuilder.AppendLine("""
-            <details><summary>🎬 <b>Terminal Recording</b></summary>
-
-        """);
+        reportBuilder.AppendLine("<details><summary>🎬 <b>Terminal Recording</b></summary>");
         reportBuilder.AppendLine();
-        reportBuilder.AppendLine("```");
+        reportBuilder.AppendLine("```ansi");
         reportBuilder.AppendLine(recordingText);
         reportBuilder.AppendLine("```");
         reportBuilder.AppendLine();

--- a/tools/GenerateTestSummary/TestSummaryGenerator.cs
+++ b/tools/GenerateTestSummary/TestSummaryGenerator.cs
@@ -256,6 +256,11 @@ sealed partial class TestSummaryGenerator
             return;
         }
 
+        // Look for CLI E2E recordings in a sibling "recordings" directory.
+        // The trx file is typically at testresults/SomeTest.trx and recordings
+        // are at testresults/recordings/{MethodName}.cast.
+        var recordingsDir = FindRecordingsDirectory(trxFilePath);
+
         var failedTests = testRun.Results.UnitTestResults.Where(r => r.Outcome == "Failed");
         if (failedTests.Any())
         {
@@ -293,11 +298,61 @@ sealed partial class TestSummaryGenerator
                 }
 
                 reportBuilder.AppendLine("```");
+
+                AppendRecordingSection(reportBuilder, recordingsDir, test.TestName);
+
                 reportBuilder.AppendLine();
                 reportBuilder.AppendLine("</div>");
             }
         }
         reportBuilder.AppendLine();
+    }
+
+    private static void AppendRecordingSection(StringBuilder reportBuilder, string? recordingsDir, string? testName)
+    {
+        if (recordingsDir is null || testName is null)
+        {
+            return;
+        }
+
+        var recordingText = CastFileReader.ReadRecordingText(recordingsDir, testName);
+        if (recordingText is null)
+        {
+            return;
+        }
+
+        reportBuilder.AppendLine();
+        reportBuilder.AppendLine("""
+            <details><summary>🎬 <b>Terminal Recording</b></summary>
+
+        """);
+        reportBuilder.AppendLine();
+        reportBuilder.AppendLine("```");
+        reportBuilder.AppendLine(recordingText);
+        reportBuilder.AppendLine("```");
+        reportBuilder.AppendLine();
+        reportBuilder.AppendLine("</details>");
+    }
+
+    /// <summary>
+    /// Searches for a "recordings" directory relative to the trx file path,
+    /// walking up the directory tree to handle nested test result layouts.
+    /// </summary>
+    private static string? FindRecordingsDirectory(string trxFilePath)
+    {
+        var dir = Path.GetDirectoryName(Path.GetFullPath(trxFilePath));
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir, "recordings");
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        return null;
     }
 
     private static string GenerateDurationStatistics(string basePath)


### PR DESCRIPTION
## Summary

When CLI E2E tests fail in CI, their Hex1b terminal recordings (`.cast` files) are uploaded as artifacts but not visible inline in the GitHub step summary. This PR adds the extracted terminal text directly in the summary.

## Changes

### `tools/GenerateTestSummary/CastFileReader.cs` (new)
- Parses asciicast v2 format (`.cast` files)
- Strips ANSI escape codes to extract plain text
- Truncates to 5KB per recording

### `tools/GenerateTestSummary/TestSummaryGenerator.cs`
- After each failed test's error/stdout section, looks for a matching `.cast` file in the `recordings/` directory
- Adds a collapsible **🎬 Terminal Recording** section with the plain-text terminal output

### Test failures (to be reverted)
- `DoctorCommandTests`: both tests have intentional `Assert.Fail` to validate recording appears in summary
- `ListStepsTests`: intentional `Assert.Fail` for a different test type

## How it works
1. CLI E2E tests record terminal sessions as `.cast` files via Hex1b
2. When `GenerateTestSummary` runs (after tests, before artifact upload), it finds `.cast` files matching failed test method names
3. The recording text is extracted, ANSI-stripped, truncated to 5KB, and embedded in a collapsible details block

## Validation
The intentional test failures in this PR will produce recordings that should appear in the step summary. Check the CI run's summary to verify.